### PR TITLE
Refactor Connection Build

### DIFF
--- a/src/python/chinook_loader.py
+++ b/src/python/chinook_loader.py
@@ -26,7 +26,7 @@ def check_for_key(in_dict: dict, key: str) -> bool:
 
 
 def check_for_schema(parsed_yaml_json: dict, in_schema: str) -> bool:
-    """Check if schema exists in parsed yaml file"""
+    """Check if target schema exists in parsed yaml file"""
     try:
         schema_list = [
             schema["name"] for schema in parsed_yaml_json["databases"][0]["schemas"]
@@ -136,7 +136,7 @@ def load_chinook_data(
             f"Function load_chinook_data: Error occurred loading {table_name}: {e}"
         )
         return False
-#####
+
 def read_table_load_yaml(file_path: str) -> dict:
     """Read in table_load.yaml"""
     try:

--- a/src/python/config/table_load.yaml
+++ b/src/python/config/table_load.yaml
@@ -4,14 +4,6 @@ metadata:
   generated_on: 2025-04-19
 version: 1
 
-connection_string:
-  database: CHINOOK
-  schema: LANDING
-  role: CHINOOK_LOADER_ROLE
-  account: pia97753.us-east-1
-  timezone: America/New_York
-  warehouse: JPK_WAREHOUSE
-
 databases:
   - name: chinook
     schemas:

--- a/src/python/utils/db_connection_helpers.py
+++ b/src/python/utils/db_connection_helpers.py
@@ -1,0 +1,51 @@
+from boto3 import Session
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+import logging
+import json
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
+def get_connection_string(profile_name: str, secret_name: str) -> str:
+    """Get connection string fro AWS Secrets"""
+    try:
+        session = Session(profile_name = profile_name)
+        client = session.client(service_name="secretsmanager", region_name="us-east-2")
+    except Exception as e:
+        logging.error(
+            f"Function get_chinook_loader_secret: Error occurred establishing {e}"
+        )
+        return ''
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId= secret_name
+        )
+        parsed_secrets = json.loads(get_secret_value_response["SecretString"])
+        logging.info(f"Function get_chinook_loader_secret: Completed successfully.")
+        return parsed_secrets['chinook_loader_conn']
+    except Exception as e:
+        logging.error(
+            f"Function get_chinook_loader_secret: Error occurred establishing {e}"
+        )
+        return ''
+
+def create_chinook_dw_engine(connect_string: str) -> Engine | bool:
+    """Open a connection to Snowflake"""
+
+    try:
+        engine = create_engine(connect_string)
+        logging.info(f'Function create_chinook_dw_engine: Completed successfully')
+        return engine
+
+    except Exception as e:
+        logging.error(f"Function create_chinook_dw_engine: Error occurred {e} ")
+        return False
+    
+def main():
+    pass
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Instead of building connection strings from parameters stored in AWS Secrets, now storing connection strings in Secrets. Removed the build connection string method. Connection string now comes from get_connection_string().